### PR TITLE
New scp03 finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A Flake8 plugin to catch common issues on Scrapy spiders.
 
 | Code  | Meaning |
 | ---   | --- |
-| SCP01 | There are URLs in start_urls whose netloc is not in allowed_domains |
-| SCP02 | There are full URLs in allowed_domains |
+| SCP01 | There are URLs in `start_urls` whose netloc is not in `allowed_domains` |
+| SCP02 | There are URLs in `allowed_domains` |
+| SCP03 | Usage of `urljoin(response.url, '/foo')` instead of `response.urljoin('/foo')` |
 
 This is a work in progress, so new issues will be added to this list.

--- a/finders/oldstyle.py
+++ b/finders/oldstyle.py
@@ -1,0 +1,20 @@
+import ast
+
+from finders import IssueFinder
+
+
+class UrlJoinIssueFinder(IssueFinder):
+    msg_code = 'SCP03'
+    msg_info = 'urljoin(response.url, "/foo") can be replaced by response.urljoin("/foo")'
+
+    def find_issues(self, node):
+        if not isinstance(node.func, ast.Name) or node.func.id != 'urljoin':
+            return
+
+        first_param = node.args[0]
+        if not isinstance(first_param, ast.Attribute):
+            return
+
+        if first_param.value.id == 'response' and first_param.attr == 'url':
+            # found it: first param to urljoin is response.url
+            yield (node.lineno, node.col_offset, self.message)

--- a/finders/oldstyle.py
+++ b/finders/oldstyle.py
@@ -8,12 +8,7 @@ class UrlJoinIssueFinder(IssueFinder):
     msg_info = 'urljoin(response.url, "/foo") can be replaced by response.urljoin("/foo")'
 
     def find_issues(self, node):
-        doesnt_apply = (
-            not isinstance(node.func, ast.Name) or
-            node.func.id != 'urljoin' or
-            not node.args
-        )
-        if doesnt_apply:
+        if not self.issue_applies(node):
             return
 
         first_param = node.args[0]
@@ -23,3 +18,10 @@ class UrlJoinIssueFinder(IssueFinder):
         if first_param.value.id == 'response' and first_param.attr == 'url':
             # found it: first param to urljoin is response.url
             yield (node.lineno, node.col_offset, self.message)
+
+    def issue_applies(self, node):
+        return (
+            isinstance(node.func, ast.Name) and
+            node.func.id == 'urljoin' and
+            node.args
+        )

--- a/finders/oldstyle.py
+++ b/finders/oldstyle.py
@@ -8,7 +8,12 @@ class UrlJoinIssueFinder(IssueFinder):
     msg_info = 'urljoin(response.url, "/foo") can be replaced by response.urljoin("/foo")'
 
     def find_issues(self, node):
-        if not isinstance(node.func, ast.Name) or node.func.id != 'urljoin':
+        doesnt_apply = (
+            not isinstance(node.func, ast.Name) or
+            node.func.id != 'urljoin' or
+            not node.args
+        )
+        if doesnt_apply:
             return
 
         first_param = node.args[0]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,19 @@
+import ast
+import os
+
+from flake8_scrapy import ScrapyStyleChecker
+
+
+def load_sample_file(filename):
+    path = os.path.join(
+        os.path.dirname(__file__),
+        'samples',
+        filename
+    )
+    return open(path).read()
+
+
+def run_checker(code):
+    tree = ast.parse(code)
+    checker = ScrapyStyleChecker(tree, None)
+    return list(checker.run())

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -1,25 +1,7 @@
-import ast
-import os
-
-from flake8_scrapy import ScrapyStyleChecker
+from . import load_sample_file, run_checker
 from finders.domains import (
     UnreachableDomainIssueFinder, UrlInAllowedDomainsIssueFinder,
 )
-
-
-def load_sample_file(filename):
-    path = os.path.join(
-        os.path.dirname(__file__),
-        'samples',
-        filename
-    )
-    return open(path).read()
-
-
-def run_checker(code):
-    tree = ast.parse(code)
-    checker = ScrapyStyleChecker(tree, None)
-    return list(checker.run())
 
 
 def test_url_not_in_allowed_domains():

--- a/tests/test_oldstyle.py
+++ b/tests/test_oldstyle.py
@@ -1,0 +1,15 @@
+import pytest
+from . import run_checker
+
+
+@pytest.mark.parametrize('code,expected,issue_code', [
+    ('response.urljoin("/foo")', 0, ''),
+    ('urljoin(response.url, "/foo")', 1, 'SCP03'),
+    ('url = urljoin(response.url, "/foo")', 1, 'SCP03'),
+])
+def test_has_old_urljoin(code, expected, issue_code):
+    issues = run_checker(code)
+    assert len(issues) == expected
+    if not issues:
+        return
+    assert issue_code in issues[0][2]

--- a/tests/test_oldstyle.py
+++ b/tests/test_oldstyle.py
@@ -6,6 +6,7 @@ from . import run_checker
     ('response.urljoin("/foo")', 0, ''),
     ('urljoin(response.url, "/foo")', 1, 'SCP03'),
     ('url = urljoin(response.url, "/foo")', 1, 'SCP03'),
+    ('url = urljoin()', 0, ''),
 ])
 def test_has_old_urljoin(code, expected, issue_code):
     issues = run_checker(code)

--- a/tests/test_oldstyle.py
+++ b/tests/test_oldstyle.py
@@ -1,16 +1,23 @@
 import pytest
+
 from . import run_checker
+from finders.oldstyle import UrlJoinIssueFinder
 
 
-@pytest.mark.parametrize('code,expected,issue_code', [
-    ('response.urljoin("/foo")', 0, ''),
-    ('urljoin(response.url, "/foo")', 1, 'SCP03'),
-    ('url = urljoin(response.url, "/foo")', 1, 'SCP03'),
-    ('url = urljoin()', 0, ''),
+@pytest.mark.parametrize('code', [
+    ('urljoin(response.url, "/foo")'),
+    ('url = urljoin(response.url, "/foo")'),
 ])
-def test_has_old_urljoin(code, expected, issue_code):
+def test_finds_old_style_urljoin(code):
     issues = run_checker(code)
-    assert len(issues) == expected
-    if not issues:
-        return
-    assert issue_code in issues[0][2]
+    assert len(issues) == 1
+    assert UrlJoinIssueFinder.msg_code in issues[0][2]
+
+
+@pytest.mark.parametrize('code', [
+    ('response.urljoin("/foo")'),
+    ('url = urljoin()'),
+])
+def test_dont_find_old_style_urljoin(code):
+    issues = run_checker(code)
+    assert len(issues) == 0


### PR DESCRIPTION
Detects the usage of `urljoin(response.url, '/foo')` instead of the more idiomatic `response.urljoin('/foo')`.